### PR TITLE
unpin blosc, update zstd

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 6e613d222c5f15537dbbd0cf121138c27d480780cc56acd5a7d1ff9f9ce0fe56
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:
@@ -18,15 +18,15 @@ requirements:
     - cmake >=3.2
     - zlib 1.2.11
     - bzip2 1.0
-    - zstd 1.3.2
+    - zstd 1.3.3
     - lz4-c 1.8.1
-    - blosc 1.12.0
+    - blosc
   run:
     - zlib 1.2.11
     - bzip2 1.0
-    - zstd 1.3.2
+    - zstd 1.3.3
     - lz4-c 1.8.1
-    - blosc 1.12.0
+    - blosc
 
 test:
   commands:


### PR DESCRIPTION
Pinning blosc is not actually necessary: https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/19#issuecomment-370034262

Also, zstd 1.3.3 is now the version to pin against: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/17