### PR TITLE
Patch TileDB build to correctly find shared libcurl

### DIFF
--- a/recipe/0002-fix-tiledb-curl.patch
+++ b/recipe/0002-fix-tiledb-curl.patch
@@ -1,0 +1,27 @@
+From f16020003d90d4070077ac944b121f4b0b7ada04 Mon Sep 17 00:00:00 2001
+From: Isaiah Norton <isaiah@tiledb.io>
+Date: Wed, 13 Nov 2019 13:53:45 -0500
+Subject: [PATCH] Fix curl find_package by removing stray 'CONFIG'
+
+This was left over from the curl/cmake iteration, and breaks this initial find_package, which causes curl to fallback to preferring the static library.
+---
+ cmake/Modules/FindCurl_EP.cmake | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/cmake/Modules/FindCurl_EP.cmake b/cmake/Modules/FindCurl_EP.cmake
+index 574fffd1..2ff7d4d2 100644
+--- a/cmake/Modules/FindCurl_EP.cmake
++++ b/cmake/Modules/FindCurl_EP.cmake
+@@ -42,8 +42,7 @@ set(CURL_PATHS ${TILEDB_EP_INSTALL_PREFIX})
+ 
+ # First try the CMake-provided find script.
+ find_package(CURL
+-  HINTS "${CURL_PATHS}"
+-  QUIET ${TILEDB_DEPS_NO_DEFAULT_PATH} CONFIG)
++  QUIET ${TILEDB_DEPS_NO_DEFAULT_PATH})
+ 
+ # Next try finding the superbuild external project
+ if (NOT CURL_FOUND)
+-- 
+2.20.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
   sha256: {{ sha256 }}
   patches:
     - 0001-Conda-only-patch-capnproto-build-to-work-with-anacon.patch
+    - 0002-fix-tiledb-curl.patch # remove in 1.7.1
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # no ABI info but the so breaks in minor releases
     - {{ pin_subpackage('tiledb') }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
