### PR TITLE
[staging] Enable TileDB build with TILEDB_SERIALIZATION support (TileDB 2.3 only)

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,6 +10,7 @@ cmake -G "NMake Makefiles" ^
       -DTILEDB_TBB_SHARED=ON ^
       -DTILEDB_S3=ON ^
       -DTILEDB_HDFS=OFF ^
+      -DTILEDB_SERIALIZATION=ON ^
       ..
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,6 +12,10 @@ if [[ $target_platform =~ osx-arm64 ]]; then
   export LDFLAGS="${LDFLAGS} ${CURL_LIBS_APPEND}"
 fi
 
+if [[ $target_platform  == linux-64 ]]; then
+  export LDFLAGS="${LDFLAGS} -Wl,--no-as-needed -lrt"
+fi
+
 mkdir build && cd build
 cmake ${CMAKE_ARGS} \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,6 @@ package:
 source:
   url: https://github.com/TileDB-Inc/{{ name }}/archive/{{ version }}.tar.gz
   sha256: d465e5606437c2cb507d8225877b8b4daf41308fd129c4aa00cb83131acc4343
-  patches:
-    - 0001-Conda-only-patch-capnproto-build-to-work-with-anacon.patch
 
 build:
   number: 0


### PR DESCRIPTION
*For merging after TileDB 2.3 is released*

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
