### PR TITLE
Fix missing max_pin keyword in run_exports

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @akrherz @ihnorton @nguyenv @shelnutt2 @stavrospapadopoulos
+* @akrherz @ihnorton @nguyenv @shelnutt2 @stavrospapadopoulos @xylar

--- a/README.md
+++ b/README.md
@@ -254,4 +254,5 @@ Feedstock Maintainers
 * [@nguyenv](https://github.com/nguyenv/)
 * [@shelnutt2](https://github.com/shelnutt2/)
 * [@stavrospapadopoulos](https://github.com/stavrospapadopoulos/)
+* [@xylar](https://github.com/xylar/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,3 +74,4 @@ extra:
     - shelnutt2
     - ihnorton
     - nguyenv
+    - xylar

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,10 @@ source:
   sha256: 212e80769199c13956e1eb31b56a510fb46ee56310234481a6aaf4a07acf2efb
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
-    - {{ pin_subpackage('tiledb', 'x.x') }}
+    - {{ pin_subpackage('tiledb', max_pin='x.x') }}
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
