### PR TITLE
[2.11.3] Fix missing max_pin keyword in run_exports

### DIFF
--- a/.ci_support/linux_64_openssl1.1.1.yaml
+++ b/.ci_support/linux_64_openssl1.1.1.yaml
@@ -18,13 +18,6 @@ lz4_c:
 - 1.9.3
 openssl:
 - 1.1.1
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  curl:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 target_platform:
 - linux-64
 zlib:

--- a/.ci_support/linux_64_openssl3.yaml
+++ b/.ci_support/linux_64_openssl3.yaml
@@ -18,13 +18,6 @@ lz4_c:
 - 1.9.3
 openssl:
 - '3'
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  curl:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 target_platform:
 - linux-64
 zlib:

--- a/.ci_support/linux_aarch64_openssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_openssl1.1.1.yaml
@@ -22,13 +22,6 @@ lz4_c:
 - 1.9.3
 openssl:
 - 1.1.1
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  curl:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 target_platform:
 - linux-aarch64
 zlib:

--- a/.ci_support/linux_aarch64_openssl3.yaml
+++ b/.ci_support/linux_aarch64_openssl3.yaml
@@ -22,13 +22,6 @@ lz4_c:
 - 1.9.3
 openssl:
 - '3'
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  curl:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 target_platform:
 - linux-aarch64
 zlib:

--- a/.ci_support/linux_ppc64le_openssl1.1.1.yaml
+++ b/.ci_support/linux_ppc64le_openssl1.1.1.yaml
@@ -18,13 +18,6 @@ lz4_c:
 - 1.9.3
 openssl:
 - 1.1.1
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  curl:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 target_platform:
 - linux-ppc64le
 zlib:

--- a/.ci_support/linux_ppc64le_openssl3.yaml
+++ b/.ci_support/linux_ppc64le_openssl3.yaml
@@ -18,13 +18,6 @@ lz4_c:
 - 1.9.3
 openssl:
 - '3'
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  curl:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 target_platform:
 - linux-ppc64le
 zlib:

--- a/.ci_support/osx_64_openssl1.1.1.yaml
+++ b/.ci_support/osx_64_openssl1.1.1.yaml
@@ -20,13 +20,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
 - 1.1.1
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  curl:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 target_platform:
 - osx-64
 zlib:

--- a/.ci_support/osx_64_openssl3.yaml
+++ b/.ci_support/osx_64_openssl3.yaml
@@ -20,13 +20,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
 - '3'
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  curl:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 target_platform:
 - osx-64
 zlib:

--- a/.ci_support/osx_arm64_openssl1.1.1.yaml
+++ b/.ci_support/osx_arm64_openssl1.1.1.yaml
@@ -18,13 +18,6 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:
 - 1.1.1
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  curl:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 target_platform:
 - osx-arm64
 zlib:

--- a/.ci_support/osx_arm64_openssl3.yaml
+++ b/.ci_support/osx_arm64_openssl3.yaml
@@ -18,13 +18,6 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:
 - '3'
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  curl:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 target_platform:
 - osx-arm64
 zlib:

--- a/.ci_support/win_64_openssl1.1.1.yaml
+++ b/.ci_support/win_64_openssl1.1.1.yaml
@@ -12,13 +12,6 @@ lz4_c:
 - 1.9.3
 openssl:
 - 1.1.1
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  curl:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 target_platform:
 - win-64
 vc:

--- a/.ci_support/win_64_openssl3.yaml
+++ b/.ci_support/win_64_openssl3.yaml
@@ -12,13 +12,6 @@ lz4_c:
 - 1.9.3
 openssl:
 - '3'
-pin_run_as_build:
-  bzip2:
-    max_pin: x
-  curl:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 target_platform:
 - win-64
 vc:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,10 @@ source:
   sha256: 30375e953ca14584008cde4d722d0b084e862304a51282bc3ce5688e122af82f
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
-    - {{ pin_subpackage('tiledb', 'x.x') }}
+    - {{ pin_subpackage('tiledb', max_pin='x.x') }}
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
