### PR TITLE
Migrate to GCC 11

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -17,6 +17,7 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
+    UPLOAD_TEMP: D:\\tmp
 
   steps:
     - task: PythonScript@0
@@ -75,6 +76,9 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
         call activate base
         upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package

--- a/.ci_support/linux_64_openssl1.1.1.yaml
+++ b/.ci_support/linux_64_openssl1.1.1.yaml
@@ -11,7 +11,7 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 lz4_c:

--- a/.ci_support/linux_64_openssl3.yaml
+++ b/.ci_support/linux_64_openssl3.yaml
@@ -11,7 +11,7 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 lz4_c:

--- a/.ci_support/linux_aarch64_openssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_openssl1.1.1.yaml
@@ -15,7 +15,7 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 lz4_c:

--- a/.ci_support/linux_aarch64_openssl3.yaml
+++ b/.ci_support/linux_aarch64_openssl3.yaml
@@ -15,7 +15,7 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 lz4_c:

--- a/.ci_support/linux_ppc64le_openssl1.1.1.yaml
+++ b/.ci_support/linux_ppc64le_openssl1.1.1.yaml
@@ -11,7 +11,7 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 lz4_c:

--- a/.ci_support/linux_ppc64le_openssl3.yaml
+++ b/.ci_support/linux_ppc64le_openssl3.yaml
@@ -11,7 +11,7 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 lz4_c:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: bc5aabc8bb2951a3882b660aa694353de7c22c5ba0a7ab12817452f3f6d2311d
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
     - {{ pin_subpackage('tiledb', max_pin='x.x') }}


### PR DESCRIPTION
conda-forge updated its GCC pinning from 10 to 11 2 weeks ago (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3731). This migration has been well tolerated by TileDB-VCF ([source](https://github.com/TileDB-Inc/tiledb-vcf-feedstock/commit/a5c01af09e591a05cdab5712f1fea2e4ad164d6d#diff-999d2f034982a9a29cc0f5a5340497f76ff9243576ea74e5954ec5ad5f32b74c)) and TileDB-R ([source](https://github.com/conda-forge/r-tiledb-feedstock/commit/31985768d7ea5747ed8d310155bdcc28cbf8e8c2#diff-d597e0d111da6b7d37902c207501f6fcbb97756bb1404c485b95d6a77918c2e7))

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
