### PR TITLE
Build variant for openssl 3 and curl 7

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,6 +12,10 @@ jobs:
         CONFIG: linux_64_curl7gcsgcs_disabledopenssl1.1.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_curl7gcsgcs_disabledopenssl3:
+        CONFIG: linux_64_curl7gcsgcs_disabledopenssl3
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_curl8gcsgcs_enabledopenssl3:
         CONFIG: linux_64_curl8gcsgcs_enabledopenssl3
         UPLOAD_PACKAGES: 'True'
@@ -20,12 +24,20 @@ jobs:
         CONFIG: linux_aarch64_curl7gcsgcs_disabledopenssl1.1.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_curl7gcsgcs_disabledopenssl3:
+        CONFIG: linux_aarch64_curl7gcsgcs_disabledopenssl3
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_curl8gcsgcs_enabledopenssl3:
         CONFIG: linux_aarch64_curl8gcsgcs_enabledopenssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_curl7gcsgcs_disabledopenssl1.1.1:
         CONFIG: linux_ppc64le_curl7gcsgcs_disabledopenssl1.1.1
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_curl7gcsgcs_disabledopenssl3:
+        CONFIG: linux_ppc64le_curl7gcsgcs_disabledopenssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_curl8gcsgcs_enabledopenssl3:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,11 +11,17 @@ jobs:
       osx_64_curl7gcsgcs_disabledopenssl1.1.1:
         CONFIG: osx_64_curl7gcsgcs_disabledopenssl1.1.1
         UPLOAD_PACKAGES: 'True'
+      osx_64_curl7gcsgcs_disabledopenssl3:
+        CONFIG: osx_64_curl7gcsgcs_disabledopenssl3
+        UPLOAD_PACKAGES: 'True'
       osx_64_curl8gcsgcs_enabledopenssl3:
         CONFIG: osx_64_curl8gcsgcs_enabledopenssl3
         UPLOAD_PACKAGES: 'True'
       osx_arm64_curl7gcsgcs_disabledopenssl1.1.1:
         CONFIG: osx_arm64_curl7gcsgcs_disabledopenssl1.1.1
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_curl7gcsgcs_disabledopenssl3:
+        CONFIG: osx_arm64_curl7gcsgcs_disabledopenssl3
         UPLOAD_PACKAGES: 'True'
       osx_arm64_curl8gcsgcs_enabledopenssl3:
         CONFIG: osx_arm64_curl8gcsgcs_enabledopenssl3

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,6 +11,9 @@ jobs:
       win_64_curl7gcsgcs_disabledopenssl1.1.1:
         CONFIG: win_64_curl7gcsgcs_disabledopenssl1.1.1
         UPLOAD_PACKAGES: 'True'
+      win_64_curl7gcsgcs_disabledopenssl3:
+        CONFIG: win_64_curl7gcsgcs_disabledopenssl3
+        UPLOAD_PACKAGES: 'True'
       win_64_curl8gcsgcs_enabledopenssl3:
         CONFIG: win_64_curl8gcsgcs_enabledopenssl3
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_64_curl7gcsgcs_disabledopenssl3.yaml
+++ b/.ci_support/linux_64_curl7gcsgcs_disabledopenssl3.yaml
@@ -1,0 +1,34 @@
+bzip2:
+- '1'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '7'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+gcs:
+- gcs_disabled
+google_cloud_cpp:
+- 2.10.1
+lz4_c:
+- 1.9.3
+openssl:
+- '3'
+target_platform:
+- linux-64
+zip_keys:
+- - gcs
+  - openssl
+  - curl
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/linux_aarch64_curl7gcsgcs_disabledopenssl3.yaml
+++ b/.ci_support/linux_aarch64_curl7gcsgcs_disabledopenssl3.yaml
@@ -1,0 +1,38 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+bzip2:
+- '1'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '7'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+gcs:
+- gcs_disabled
+google_cloud_cpp:
+- 2.10.1
+lz4_c:
+- 1.9.3
+openssl:
+- '3'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - gcs
+  - openssl
+  - curl
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/linux_ppc64le_curl7gcsgcs_disabledopenssl3.yaml
+++ b/.ci_support/linux_ppc64le_curl7gcsgcs_disabledopenssl3.yaml
@@ -1,0 +1,34 @@
+bzip2:
+- '1'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '7'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+gcs:
+- gcs_disabled
+google_cloud_cpp:
+- 2.10.1
+lz4_c:
+- 1.9.3
+openssl:
+- '3'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - gcs
+  - openssl
+  - curl
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/osx_64_curl7gcsgcs_disabledopenssl3.yaml
+++ b/.ci_support/osx_64_curl7gcsgcs_disabledopenssl3.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.15'
+bzip2:
+- '1'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '7'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '15'
+gcs:
+- gcs_disabled
+google_cloud_cpp:
+- 2.10.1
+lz4_c:
+- 1.9.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+openssl:
+- '3'
+target_platform:
+- osx-64
+zip_keys:
+- - gcs
+  - openssl
+  - curl
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/osx_arm64_curl7gcsgcs_disabledopenssl3.yaml
+++ b/.ci_support/osx_arm64_curl7gcsgcs_disabledopenssl3.yaml
@@ -1,0 +1,34 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+bzip2:
+- '1'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '7'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '15'
+gcs:
+- gcs_disabled
+google_cloud_cpp:
+- 2.10.1
+lz4_c:
+- 1.9.3
+macos_machine:
+- arm64-apple-darwin20.0.0
+openssl:
+- '3'
+target_platform:
+- osx-arm64
+zip_keys:
+- - gcs
+  - openssl
+  - curl
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/win_64_curl7gcsgcs_disabledopenssl3.yaml
+++ b/.ci_support/win_64_curl7gcsgcs_disabledopenssl3.yaml
@@ -1,0 +1,34 @@
+bzip2:
+- '1'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '7'
+cxx_compiler:
+- vs2019
+gcs:
+- gcs_disabled
+google_cloud_cpp:
+- 2.10.1
+libcrc32c:
+- '1.1'
+libcurl:
+- '8'
+lz4_c:
+- 1.9.3
+openssl:
+- '3'
+target_platform:
+- win-64
+vc:
+- '14'
+zip_keys:
+- - gcs
+  - openssl
+  - curl
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_curl7gcsgcs_disabledopenssl3</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_curl7gcsgcs_disabledopenssl3" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_curl8gcsgcs_enabledopenssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
@@ -55,6 +62,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_curl7gcsgcs_disabledopenssl1.1.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_curl7gcsgcs_disabledopenssl3</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_curl7gcsgcs_disabledopenssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -72,6 +86,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_ppc64le_curl7gcsgcs_disabledopenssl3</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_curl7gcsgcs_disabledopenssl3" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_ppc64le_curl8gcsgcs_enabledopenssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
@@ -83,6 +104,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_curl7gcsgcs_disabledopenssl1.1.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_curl7gcsgcs_disabledopenssl3</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_curl7gcsgcs_disabledopenssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -100,6 +128,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_curl7gcsgcs_disabledopenssl3</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_curl7gcsgcs_disabledopenssl3" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_arm64_curl8gcsgcs_enabledopenssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
@@ -111,6 +146,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=win&configuration=win%20win_64_curl7gcsgcs_disabledopenssl1.1.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_curl7gcsgcs_disabledopenssl3</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=win&configuration=win%20win_64_curl7gcsgcs_disabledopenssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,10 +10,13 @@ cxx_compiler:
 openssl:
 - '1.1.1'
 - '3'
+- '3'
 curl:
+- 7
 - 7
 - 8
 gcs:
+- gcs_disabled
 - gcs_disabled
 - gcs_enabled
 zip_keys:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 840d0147e50f68c5adc23600f0e64129894d66020503ad0f23a4e34b1a0d04fa
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
     - {{ pin_subpackage('tiledb', max_pin='x.x') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This introduce another build variant for openssl 3 with curl 7. We've seen some downstream packages like TileDB-SOMA that pull in other dependencies in a long dependency chain that might need this build variant. @jdblischak has been investigating some resolver issues. I'd like to propose adding this build variant to see if it helps. TileDB packages (like most conda packages) had a combo of curl 7 and openssl 3 previously until the global curl 8 migration took place.

<!--
Please add any other relevant info below:
-->
