### PR TITLE
Patch azure linking order to avoid misisng symbol

### DIFF
--- a/recipe/0001-Fix-order-of-azure-static-library-linking.patch
+++ b/recipe/0001-Fix-order-of-azure-static-library-linking.patch
@@ -1,0 +1,43 @@
+From a3106d8157cf6fffd1dfd755c366cb6b982c95a7 Mon Sep 17 00:00:00 2001
+From: Seth Shelnutt <seth@tiledb.io>
+Date: Fri, 14 Jul 2023 10:12:21 -0400
+Subject: [PATCH] Fix order of azure static library linking
+
+This solves the missing symbol error by linking the azure-storage-common
+library before the azure-storage-blobs library.
+
+Error solved:
+```
+libtiledb.so.2.16: undefined symbol: _ZN5Azure7Storage9_internal23UrlEncodeQueryParameterERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+```
+---
+ tiledb/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tiledb/CMakeLists.txt b/tiledb/CMakeLists.txt
+index 8f391fa0c..4ae46b552 100644
+--- a/tiledb/CMakeLists.txt
++++ b/tiledb/CMakeLists.txt
+@@ -545,8 +545,8 @@ if (TILEDB_AZURE)
+     endif()
+     target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
+             INTERFACE
+-            Azure::azure-storage-blobs
+             Azure::azure-storage-common
++            Azure::azure-storage-blobs
+             Azure::azure-core
+             LibXml2::LibXml2
+             LibLZMA::LibLZMA
+@@ -562,8 +562,8 @@ if (TILEDB_AZURE)
+     endif()
+     target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
+             INTERFACE
+-            Azure::azure-storage-common
+             Azure::azure-storage-blobs
++            Azure::azure-storage-common
+             Azure::azure-core
+             LibXml2::LibXml2)
+     if(WIN32)
+-- 
+2.40.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,11 @@ package:
 source:
   url: https://github.com/TileDB-Inc/{{ name }}/archive/{{ version }}.tar.gz
   sha256: eaf47fbeb36a5fccce194b89a0101609c9122639b2c9ce590dce2e2c2b7f81f9
+  patches:
+    - 0001-Fix-order-of-azure-static-library-linking.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
     - {{ pin_subpackage('tiledb', min_pin='x.x', max_pin='x.x') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This adds a patch to change the linking order of the static azure libraries to avoid the missing symbol error.

<!--
Please add any other relevant info below:
-->
