### PR TITLE
Remove min_pin to return to default run_exports of x.x.x.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,10 +11,10 @@ source:
   sha256: 5e6cb409622f246117713ea79592b3044e712d050fdbc63505e85d892add9813
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
-    - {{ pin_subpackage('tiledb', min_pin='x.x', max_pin='x.x') }}
+    - {{ pin_subpackage('tiledb', max_pin='x.x') }}
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

This is a follow up to PR #214 which updated the recipe to 2.17.3. This version introduced a new API, and thus downstream clients built against 2.17.3 are not compatible with earlier 2.17.x versions.

cc: @ihnorton 
xref: https://github.com/conda-forge/tiledb-py-feedstock/pull/182, https://github.com/conda-forge/staged-recipes/pull/23297#discussion_r1279977690