### PR TITLE
Require libcurl

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,40 +8,40 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_curl7gcsgcs_disabledopenssl1.1.1:
-        CONFIG: linux_64_curl7gcsgcs_disabledopenssl1.1.1
+      linux_64_gcsgcs_disabledlibcurl7openssl1.1.1:
+        CONFIG: linux_64_gcsgcs_disabledlibcurl7openssl1.1.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_curl7gcsgcs_disabledopenssl3:
-        CONFIG: linux_64_curl7gcsgcs_disabledopenssl3
+      linux_64_gcsgcs_disabledlibcurl7openssl3:
+        CONFIG: linux_64_gcsgcs_disabledlibcurl7openssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_curl8gcsgcs_enabledopenssl3:
-        CONFIG: linux_64_curl8gcsgcs_enabledopenssl3
+      linux_64_gcsgcs_enabledlibcurl8openssl3:
+        CONFIG: linux_64_gcsgcs_enabledlibcurl8openssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_curl7gcsgcs_disabledopenssl1.1.1:
-        CONFIG: linux_aarch64_curl7gcsgcs_disabledopenssl1.1.1
+      linux_aarch64_gcsgcs_disabledlibcurl7openssl1.1.1:
+        CONFIG: linux_aarch64_gcsgcs_disabledlibcurl7openssl1.1.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_curl7gcsgcs_disabledopenssl3:
-        CONFIG: linux_aarch64_curl7gcsgcs_disabledopenssl3
+      linux_aarch64_gcsgcs_disabledlibcurl7openssl3:
+        CONFIG: linux_aarch64_gcsgcs_disabledlibcurl7openssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_curl8gcsgcs_enabledopenssl3:
-        CONFIG: linux_aarch64_curl8gcsgcs_enabledopenssl3
+      linux_aarch64_gcsgcs_enabledlibcurl8openssl3:
+        CONFIG: linux_aarch64_gcsgcs_enabledlibcurl8openssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_curl7gcsgcs_disabledopenssl1.1.1:
-        CONFIG: linux_ppc64le_curl7gcsgcs_disabledopenssl1.1.1
+      linux_ppc64le_gcsgcs_disabledlibcurl7openssl1.1.1:
+        CONFIG: linux_ppc64le_gcsgcs_disabledlibcurl7openssl1.1.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_curl7gcsgcs_disabledopenssl3:
-        CONFIG: linux_ppc64le_curl7gcsgcs_disabledopenssl3
+      linux_ppc64le_gcsgcs_disabledlibcurl7openssl3:
+        CONFIG: linux_ppc64le_gcsgcs_disabledlibcurl7openssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_curl8gcsgcs_enabledopenssl3:
-        CONFIG: linux_ppc64le_curl8gcsgcs_enabledopenssl3
+      linux_ppc64le_gcsgcs_enabledlibcurl8openssl3:
+        CONFIG: linux_ppc64le_gcsgcs_enabledlibcurl8openssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,23 +8,23 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_curl7gcsgcs_disabledopenssl1.1.1:
-        CONFIG: osx_64_curl7gcsgcs_disabledopenssl1.1.1
+      osx_64_gcsgcs_disabledlibcurl7openssl1.1.1:
+        CONFIG: osx_64_gcsgcs_disabledlibcurl7openssl1.1.1
         UPLOAD_PACKAGES: 'True'
-      osx_64_curl7gcsgcs_disabledopenssl3:
-        CONFIG: osx_64_curl7gcsgcs_disabledopenssl3
+      osx_64_gcsgcs_disabledlibcurl7openssl3:
+        CONFIG: osx_64_gcsgcs_disabledlibcurl7openssl3
         UPLOAD_PACKAGES: 'True'
-      osx_64_curl8gcsgcs_enabledopenssl3:
-        CONFIG: osx_64_curl8gcsgcs_enabledopenssl3
+      osx_64_gcsgcs_enabledlibcurl8openssl3:
+        CONFIG: osx_64_gcsgcs_enabledlibcurl8openssl3
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_curl7gcsgcs_disabledopenssl1.1.1:
-        CONFIG: osx_arm64_curl7gcsgcs_disabledopenssl1.1.1
+      osx_arm64_gcsgcs_disabledlibcurl7openssl1.1.1:
+        CONFIG: osx_arm64_gcsgcs_disabledlibcurl7openssl1.1.1
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_curl7gcsgcs_disabledopenssl3:
-        CONFIG: osx_arm64_curl7gcsgcs_disabledopenssl3
+      osx_arm64_gcsgcs_disabledlibcurl7openssl3:
+        CONFIG: osx_arm64_gcsgcs_disabledlibcurl7openssl3
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_curl8gcsgcs_enabledopenssl3:
-        CONFIG: osx_arm64_curl8gcsgcs_enabledopenssl3
+      osx_arm64_gcsgcs_enabledlibcurl8openssl3:
+        CONFIG: osx_arm64_gcsgcs_enabledlibcurl8openssl3
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,14 +8,14 @@ jobs:
     vmImage: windows-2019
   strategy:
     matrix:
-      win_64_curl7gcsgcs_disabledopenssl1.1.1:
-        CONFIG: win_64_curl7gcsgcs_disabledopenssl1.1.1
+      win_64_gcsgcs_disabledlibcurl7openssl1.1.1:
+        CONFIG: win_64_gcsgcs_disabledlibcurl7openssl1.1.1
         UPLOAD_PACKAGES: 'True'
-      win_64_curl7gcsgcs_disabledopenssl3:
-        CONFIG: win_64_curl7gcsgcs_disabledopenssl3
+      win_64_gcsgcs_disabledlibcurl7openssl3:
+        CONFIG: win_64_gcsgcs_disabledlibcurl7openssl3
         UPLOAD_PACKAGES: 'True'
-      win_64_curl8gcsgcs_enabledopenssl3:
-        CONFIG: win_64_curl8gcsgcs_enabledopenssl3
+      win_64_gcsgcs_enabledlibcurl8openssl3:
+        CONFIG: win_64_gcsgcs_enabledlibcurl8openssl3
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_gcsgcs_disabledlibcurl7openssl1.1.1.yaml
+++ b/.ci_support/linux_64_gcsgcs_disabledlibcurl7openssl1.1.1.yaml
@@ -1,39 +1,37 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
-MACOSX_SDK_VERSION:
-- '10.15'
 bzip2:
 - '1'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '16'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 gcs:
 - gcs_disabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcurl:
+- '7'
 libxml2:
 - '2.12'
 lz4_c:
 - 1.9.3
-macos_machine:
-- x86_64-apple-darwin13.4.0
 openssl:
-- '3'
+- 1.1.1
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_64_gcsgcs_disabledlibcurl7openssl3.yaml
+++ b/.ci_support/linux_64_gcsgcs_disabledlibcurl7openssl3.yaml
@@ -1,39 +1,37 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
-MACOSX_SDK_VERSION:
-- '10.15'
 bzip2:
 - '1'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '16'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 gcs:
-- gcs_enabled
+- gcs_disabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcurl:
+- '7'
 libxml2:
 - '2.12'
 lz4_c:
 - 1.9.3
-macos_machine:
-- x86_64-apple-darwin13.4.0
 openssl:
 - '3'
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_64_gcsgcs_enabledlibcurl8openssl3.yaml
+++ b/.ci_support/linux_64_gcsgcs_enabledlibcurl8openssl3.yaml
@@ -1,39 +1,37 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
-MACOSX_SDK_VERSION:
-- '10.15'
 bzip2:
 - '1'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '16'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 gcs:
-- gcs_disabled
+- gcs_enabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcurl:
+- '8'
 libxml2:
 - '2.12'
 lz4_c:
 - 1.9.3
-macos_machine:
-- x86_64-apple-darwin13.4.0
 openssl:
-- 1.1.1
+- '3'
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_aarch64_gcsgcs_disabledlibcurl7openssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_gcsgcs_disabledlibcurl7openssl1.1.1.yaml
@@ -10,8 +10,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -24,18 +22,20 @@ google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcurl:
+- '7'
 libxml2:
 - '2.12'
 lz4_c:
 - 1.9.3
 openssl:
-- '3'
+- 1.1.1
 target_platform:
 - linux-aarch64
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_aarch64_gcsgcs_disabledlibcurl7openssl3.yaml
+++ b/.ci_support/linux_aarch64_gcsgcs_disabledlibcurl7openssl3.yaml
@@ -10,8 +10,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -19,11 +17,13 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gcs:
-- gcs_enabled
+- gcs_disabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcurl:
+- '7'
 libxml2:
 - '2.12'
 lz4_c:
@@ -35,7 +35,7 @@ target_platform:
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_aarch64_gcsgcs_enabledlibcurl8openssl3.yaml
+++ b/.ci_support/linux_aarch64_gcsgcs_enabledlibcurl8openssl3.yaml
@@ -1,13 +1,15 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 bzip2:
 - '1'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -20,6 +22,8 @@ google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcurl:
+- '8'
 libxml2:
 - '2.12'
 lz4_c:
@@ -27,11 +31,11 @@ lz4_c:
 openssl:
 - '3'
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_ppc64le_gcsgcs_disabledlibcurl7openssl1.1.1.yaml
+++ b/.ci_support/linux_ppc64le_gcsgcs_disabledlibcurl7openssl1.1.1.yaml
@@ -1,17 +1,11 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 bzip2:
 - '1'
-cdt_arch:
-- aarch64
 cdt_name:
 - cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -24,6 +18,8 @@ google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcurl:
+- '7'
 libxml2:
 - '2.12'
 lz4_c:
@@ -31,11 +27,11 @@ lz4_c:
 openssl:
 - 1.1.1
 target_platform:
-- linux-aarch64
+- linux-ppc64le
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_ppc64le_gcsgcs_disabledlibcurl7openssl3.yaml
+++ b/.ci_support/linux_ppc64le_gcsgcs_disabledlibcurl7openssl3.yaml
@@ -1,37 +1,37 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 bzip2:
 - '1'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '16'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 gcs:
 - gcs_disabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcurl:
+- '7'
 libxml2:
 - '2.12'
 lz4_c:
 - 1.9.3
-macos_machine:
-- arm64-apple-darwin20.0.0
 openssl:
-- 1.1.1
+- '3'
 target_platform:
-- osx-arm64
+- linux-ppc64le
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_ppc64le_gcsgcs_enabledlibcurl8openssl3.yaml
+++ b/.ci_support/linux_ppc64le_gcsgcs_enabledlibcurl8openssl3.yaml
@@ -1,21 +1,23 @@
 bzip2:
 - '1'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
-- vs2019
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 gcs:
-- gcs_disabled
+- gcs_enabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
-libcrc32c:
-- '1.1'
 libcurl:
 - '8'
 libxml2:
@@ -25,13 +27,11 @@ lz4_c:
 openssl:
 - '3'
 target_platform:
-- win-64
-vc:
-- '14'
+- linux-ppc64le
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_64_gcsgcs_disabledlibcurl7openssl1.1.1.yaml
+++ b/.ci_support/osx_64_gcsgcs_disabledlibcurl7openssl1.1.1.yaml
@@ -1,37 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.15'
 bzip2:
 - '1'
-cdt_name:
-- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 gcs:
 - gcs_disabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcurl:
+- '7'
 libxml2:
 - '2.12'
 lz4_c:
 - 1.9.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
 openssl:
 - 1.1.1
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_64_gcsgcs_disabledlibcurl7openssl3.yaml
+++ b/.ci_support/osx_64_gcsgcs_disabledlibcurl7openssl3.yaml
@@ -1,37 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.15'
 bzip2:
 - '1'
-cdt_name:
-- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 gcs:
 - gcs_disabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcurl:
+- '7'
 libxml2:
 - '2.12'
 lz4_c:
 - 1.9.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
 openssl:
-- 1.1.1
+- '3'
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_64_gcsgcs_enabledlibcurl8openssl3.yaml
+++ b/.ci_support/osx_64_gcsgcs_enabledlibcurl8openssl3.yaml
@@ -1,37 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.15'
 bzip2:
 - '1'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
-- vs2019
+- clangxx
+cxx_compiler_version:
+- '16'
 gcs:
-- gcs_disabled
+- gcs_enabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
-libcrc32c:
-- '1.1'
 libcurl:
 - '8'
 libxml2:
 - '2.12'
 lz4_c:
 - 1.9.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
 openssl:
-- 1.1.1
+- '3'
 target_platform:
-- win-64
-vc:
-- '14'
+- osx-64
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_arm64_gcsgcs_disabledlibcurl7openssl1.1.1.yaml
+++ b/.ci_support/osx_arm64_gcsgcs_disabledlibcurl7openssl1.1.1.yaml
@@ -6,8 +6,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
@@ -18,6 +16,8 @@ google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcurl:
+- '7'
 libxml2:
 - '2.12'
 lz4_c:
@@ -25,13 +25,13 @@ lz4_c:
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:
-- '3'
+- 1.1.1
 target_platform:
 - osx-arm64
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_arm64_gcsgcs_disabledlibcurl7openssl3.yaml
+++ b/.ci_support/osx_arm64_gcsgcs_disabledlibcurl7openssl3.yaml
@@ -1,37 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 bzip2:
 - '1'
-cdt_name:
-- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 gcs:
 - gcs_disabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcurl:
+- '7'
 libxml2:
 - '2.12'
 lz4_c:
 - 1.9.3
+macos_machine:
+- arm64-apple-darwin20.0.0
 openssl:
 - '3'
 target_platform:
-- linux-64
+- osx-arm64
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_arm64_gcsgcs_enabledlibcurl8openssl3.yaml
+++ b/.ci_support/osx_arm64_gcsgcs_enabledlibcurl8openssl3.yaml
@@ -1,37 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 bzip2:
 - '1'
-cdt_name:
-- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 gcs:
 - gcs_enabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcurl:
+- '8'
 libxml2:
 - '2.12'
 lz4_c:
 - 1.9.3
+macos_machine:
+- arm64-apple-darwin20.0.0
 openssl:
 - '3'
 target_platform:
-- linux-64
+- osx-arm64
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/win_64_gcsgcs_disabledlibcurl7openssl1.1.1.yaml
+++ b/.ci_support/win_64_gcsgcs_disabledlibcurl7openssl1.1.1.yaml
@@ -1,37 +1,35 @@
 bzip2:
 - '1'
-cdt_name:
-- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- vs2019
 gcs:
 - gcs_disabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcrc32c:
+- '1.1'
+libcurl:
+- '7'
 libxml2:
 - '2.12'
 lz4_c:
 - 1.9.3
 openssl:
-- '3'
+- 1.1.1
 target_platform:
-- linux-ppc64le
+- win-64
+vc:
+- '14'
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/win_64_gcsgcs_disabledlibcurl7openssl3.yaml
+++ b/.ci_support/win_64_gcsgcs_disabledlibcurl7openssl3.yaml
@@ -4,12 +4,10 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - vs2019
 gcs:
-- gcs_enabled
+- gcs_disabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
@@ -17,7 +15,7 @@ libabseil:
 libcrc32c:
 - '1.1'
 libcurl:
-- '8'
+- '7'
 libxml2:
 - '2.12'
 lz4_c:
@@ -31,7 +29,7 @@ vc:
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/win_64_gcsgcs_enabledlibcurl8openssl3.yaml
+++ b/.ci_support/win_64_gcsgcs_enabledlibcurl8openssl3.yaml
@@ -1,37 +1,35 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 bzip2:
 - '1'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '16'
+- vs2019
 gcs:
 - gcs_enabled
 google_cloud_cpp:
 - '2.12'
 libabseil:
 - '20230802'
+libcrc32c:
+- '1.1'
+libcurl:
+- '8'
 libxml2:
 - '2.12'
 lz4_c:
 - 1.9.3
-macos_machine:
-- arm64-apple-darwin20.0.0
 openssl:
 - '3'
 target_platform:
-- osx-arm64
+- win-64
+vc:
+- '14'
 zip_keys:
 - - gcs
   - openssl
-  - curl
+  - libcurl
 zlib:
 - '1.2'
 zstd:

--- a/README.md
+++ b/README.md
@@ -37,129 +37,129 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_curl7gcsgcs_disabledopenssl1.1.1</td>
+              <td>linux_64_gcsgcs_disabledlibcurl7openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_curl7gcsgcs_disabledopenssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_gcsgcs_disabledlibcurl7openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_curl7gcsgcs_disabledopenssl3</td>
+              <td>linux_64_gcsgcs_disabledlibcurl7openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_curl7gcsgcs_disabledopenssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_gcsgcs_disabledlibcurl7openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_curl8gcsgcs_enabledopenssl3</td>
+              <td>linux_64_gcsgcs_enabledlibcurl8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_curl8gcsgcs_enabledopenssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_gcsgcs_enabledlibcurl8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_curl7gcsgcs_disabledopenssl1.1.1</td>
+              <td>linux_aarch64_gcsgcs_disabledlibcurl7openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_curl7gcsgcs_disabledopenssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_gcsgcs_disabledlibcurl7openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_curl7gcsgcs_disabledopenssl3</td>
+              <td>linux_aarch64_gcsgcs_disabledlibcurl7openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_curl7gcsgcs_disabledopenssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_gcsgcs_disabledlibcurl7openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_curl8gcsgcs_enabledopenssl3</td>
+              <td>linux_aarch64_gcsgcs_enabledlibcurl8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_curl8gcsgcs_enabledopenssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_gcsgcs_enabledlibcurl8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_curl7gcsgcs_disabledopenssl1.1.1</td>
+              <td>linux_ppc64le_gcsgcs_disabledlibcurl7openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_curl7gcsgcs_disabledopenssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_gcsgcs_disabledlibcurl7openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_curl7gcsgcs_disabledopenssl3</td>
+              <td>linux_ppc64le_gcsgcs_disabledlibcurl7openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_curl7gcsgcs_disabledopenssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_gcsgcs_disabledlibcurl7openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_curl8gcsgcs_enabledopenssl3</td>
+              <td>linux_ppc64le_gcsgcs_enabledlibcurl8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_curl8gcsgcs_enabledopenssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_gcsgcs_enabledlibcurl8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_curl7gcsgcs_disabledopenssl1.1.1</td>
+              <td>osx_64_gcsgcs_disabledlibcurl7openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_curl7gcsgcs_disabledopenssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_gcsgcs_disabledlibcurl7openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_curl7gcsgcs_disabledopenssl3</td>
+              <td>osx_64_gcsgcs_disabledlibcurl7openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_curl7gcsgcs_disabledopenssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_gcsgcs_disabledlibcurl7openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_curl8gcsgcs_enabledopenssl3</td>
+              <td>osx_64_gcsgcs_enabledlibcurl8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_curl8gcsgcs_enabledopenssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_gcsgcs_enabledlibcurl8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_curl7gcsgcs_disabledopenssl1.1.1</td>
+              <td>osx_arm64_gcsgcs_disabledlibcurl7openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_curl7gcsgcs_disabledopenssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_gcsgcs_disabledlibcurl7openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_curl7gcsgcs_disabledopenssl3</td>
+              <td>osx_arm64_gcsgcs_disabledlibcurl7openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_curl7gcsgcs_disabledopenssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_gcsgcs_disabledlibcurl7openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_curl8gcsgcs_enabledopenssl3</td>
+              <td>osx_arm64_gcsgcs_enabledlibcurl8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_curl8gcsgcs_enabledopenssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_gcsgcs_enabledlibcurl8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_curl7gcsgcs_disabledopenssl1.1.1</td>
+              <td>win_64_gcsgcs_disabledlibcurl7openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=win&configuration=win%20win_64_curl7gcsgcs_disabledopenssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=win&configuration=win%20win_64_gcsgcs_disabledlibcurl7openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_curl7gcsgcs_disabledopenssl3</td>
+              <td>win_64_gcsgcs_disabledlibcurl7openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=win&configuration=win%20win_64_curl7gcsgcs_disabledopenssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=win&configuration=win%20win_64_gcsgcs_disabledlibcurl7openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_curl8gcsgcs_enabledopenssl3</td>
+              <td>win_64_gcsgcs_enabledlibcurl8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2075&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=win&configuration=win%20win_64_curl8gcsgcs_enabledopenssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-feedstock?branchName=main&jobName=win&configuration=win%20win_64_gcsgcs_enabledlibcurl8openssl3" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -11,7 +11,7 @@ openssl:
 - '1.1.1'
 - '3'
 - '3'
-curl:
+libcurl:
 - 7
 - 7
 - 8
@@ -22,4 +22,4 @@ gcs:
 zip_keys:
 - gcs
 - openssl
-- curl
+- libcurl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 9514856314b859d3d10fcdcf9e4999aead5c09dc5f37d10db68df73a5982bd2f
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
     - {{ pin_subpackage('tiledb', max_pin='x.x') }}
@@ -26,7 +26,7 @@ requirements:
     - file  # [arm64]
   host:
     - bzip2
-    - curl
+    - libcurl
     - lz4-c
     - google-cloud-cpp  # [gcs == 'gcs_enabled']
     - libabseil  # [gcs == 'gcs_enabled']
@@ -35,7 +35,6 @@ requirements:
     - zstd
     # see: https://github.com/conda-forge/google-cloud-cpp-feedstock/pull/108,
     - libcrc32c  # [gcs == 'gcs_enabled' and win]
-    - libcurl    # [gcs == 'gcs_enabled' and win]
     - libxml2
 test:
   requires:
@@ -53,7 +52,12 @@ test:
     - if exist %LIBRARY_INC%\\tiledb\\tiledb.h (exit 0) else (exit 1)  # [win]
     - if exist %LIBRARY_LIB%\\tiledb.lib (exit 0) else (exit 1)  # [win]
     - if exist %LIBRARY_LIB%\\cmake\\TileDB\\TileDBConfig.cmake (exit 0) else (exit 1)  # [win]
-    - if exist %PREFIX%\\Library\\bin\\tiledb.dll (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_BIN%\\tiledb.dll (exit 0) else (exit 1)  # [win]
+
+    # libcurl must be installed at runtime
+    - test -e $PREFIX/lib/libcurl$SHLIB_EXT  # [not win]
+    - if exist %LIBRARY_LIB%\\libcurl.lib (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_BIN%\\libcurl.dll (exit 0) else (exit 1)  # [win]
 
 about:
   home: http://tiledb.io


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

---

Closes #224. Supersedes #223 

The new tests I added would have caught the missing `libcurl.dll` on the one Windows build variant. From the [latest build log of the variant win_64_curl7gcsgcs_disabledopenssl1.1.1](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=835215&view=logs&j=171a126d-c574-5c8c-1269-ff3b989e923d&t=623c2ba8-c4f1-582d-6c78-1c7699e2e0a2), we can see that `libcurl` was not installed at runtime in the test section, which in the future will trigger an error.

Unfortunately this test is only somewhat effective. Normally the test requirement `cmake` pulls in `libcurl`. It just so happens that installing `cmake` along with `openssl` 1 on Windows doesn't pull in `libcurl`, which is how we identified the missing `libcurl.dll` in the first place.

```sh
# Ubuntu
mamba create --dry-run -n test cmake | grep curl
## + libcurl                 8.5.0  hca28451_0   conda-forge      389kB

mamba create --dry-run -n test cmake openssl=1 | grep curl
## + libcurl                7.87.0  h6312ad2_0   conda-forge      347kB
```

```batch
rem Windows
mamba create --dry-run -n test cmake | findstr curl
rem + libcurl                 8.5.0  hd5e4a3a_0   conda-forge/win-64      324kB

mamba create --dry-run -n test cmake openssl=1 | findstr curl
rem Missing!
```