### PR TITLE
Require azure-core-cpp <1.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - {{ compiler('cxx') }}
     - file  # [arm64]
   host:
-    - azure-core-cpp
+    - azure-core-cpp <1.11
     - azure-storage-common-cpp
     - azure-storage-blobs-cpp
     - bzip2


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

The recent release of azure-core-cpp 1.11.0 (which is supposed to be backwards compatible with `1.x`) has unexpectedly broken the `tiledb` conda binary. This PR is a temporary stop-gap measure to prevent uploading any future binaries that allow being co-installed with azure-core-cpp >= 1.11 until we can identify and fix the problem upstream.

Note that I purposefully did **not** bump the build number or rerender. I don't want new binaries uploaded from this PR. It is simply to prevent any new uploads (eg that are triggered by automated migrations) until we can fix the problem. Ideally this pin will be removed in the next update PR.

xref: https://github.com/conda-forge/azure-core-cpp-feedstock/pull/10#issuecomment-1890518009 and https://github.com/conda-forge/admin-requests/pull/911