### PR TITLE
[ci skip] Backport ABI migration PRs to 2.19.x branch

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,6 +2,9 @@ azure:
   settings_win:
     pool:
       vmImage: windows-2019
+bot:
+  abi_migration_branches:
+    - 2.19.x
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64


### PR DESCRIPTION
Companion PR to #246. Copied the [arrow-cpp-feedstock method](https://github.com/conda-forge/arrow-cpp-feedstock/blob/161d0c0ef5259f93699c4c9d0b63816a872c6d1f/conda-forge.yml#L5) for backporting ABI migration PRs.