### PR TITLE
Use `-D_LIBCPP_DISABLE_AVAILABILITY` to fix macOS SDK errors

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
-MACOSX_SDK_VERSION:
-- '10.15'
+- '10.13'
 aws_crt_cpp:
 - 0.26.2
 aws_sdk_cpp:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,6 +11,11 @@ export CXX=$RECIPE_DIR/cxx_wrap.sh
 export CC=$RECIPE_DIR/cc_wrap.sh
 export CMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}
 
+# https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk
+if [[ $target_platform == osx-64  ]]; then
+  CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
 CURL_LIBS_APPEND=`$PREFIX/bin/curl-config --libs`
 export LDFLAGS="${LDFLAGS} ${CURL_LIBS_APPEND}"
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-MACOSX_SDK_VERSION:  # [osx and x86_64]
-  - 10.15            # [osx and x86_64]
-MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
-  - "10.14"                # [osx and x86_64]


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

---

Fixes https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/63. Our nightly osx-64 builds are failing due to macOS SDK errors.

In this PR I applied the [preferred conda-forge workaround](https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk) to add `-D_LIBCPP_DISABLE_AVAILABILITY` to `CXXFLAGS`. I also removed our custom values of `MACOSX_DEPLOYMENT_TARGET` and `MACOSX_SDK_VERSION` since manually configuring these values is [discouraged by conda-forge](https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks). I assume this should not affect downstream builds of clients that link against libtiledb, but please let me know if I am mistaken.

Also, I didn't bump the build number. We don't need new binaries. I just want this merged to fix our nightlies.

