### PR TITLE
[ci skip] Backport ABI migration PRs to 2.20.x branch

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -15,3 +15,6 @@ provider:
 test: native_and_emulated
 travis:
   osx_image: xcode6.4
+bot:
+  abi_migration_branches:
+    - 2.20.x


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

We are once again getting solver errors in tiledbsoma-feedstock (https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/108) because the previous release of tiledb stopped receiving migration PRs.

I've already created a new branch [2.20.x](https://github.com/conda-forge/tiledb-feedstock/tree/2.20.x) from 53fe49011f4f2f1184dca54a02bde5132a47ff40:

```sh
git checkout 53fe49011f4f2f1184dca54a02bde5132a47ff40
git checkout -b 2.20.x
git push upstream 2.20.x
```

Note that my previous backport of 2.19.x from #247 was already removed (accidentally) by #248