### PR TITLE
Remove pin to cmake <3.29.1.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ build:
 requirements:
   build:
     - make  # [unix]
-    - cmake
+    - cmake !=3.29.1
     - ninja  # [win]
     - pkg-config  # [not win]
     - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ build:
 requirements:
   build:
     - make  # [unix]
-    - cmake <3.29.1
+    - cmake
     - ninja  # [win]
     - pkg-config  # [not win]
     - {{ compiler('cxx') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering) (no changes made)
* [X] Ensured the license file is being packaged.

Fixes TileDB-Inc/conda-forge-nightly-controller#83.

We pass an (undocumented) option when configuring TileDB that has the effect of disabling making an outer "superbuild" build tree, which is no longer needed now that we are using vcpkg. Without the superbuild, configuring TileDB no longer fails on CMake 3.29.1 (for reasons I don't know), allowing us to remove the pin to version `<3.29.1`.