### PR TITLE
Use upstream libwebp.

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -32,6 +32,8 @@ libgoogle_cloud_devel:
 - '2.22'
 libgoogle_cloud_storage_devel:
 - '2.22'
+libwebp_base:
+- '1'
 libxml2:
 - '2'
 lz4_c:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -36,6 +36,8 @@ libgoogle_cloud_devel:
 - '2.22'
 libgoogle_cloud_storage_devel:
 - '2.22'
+libwebp_base:
+- '1'
 libxml2:
 - '2'
 lz4_c:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -32,6 +32,8 @@ libgoogle_cloud_devel:
 - '2.22'
 libgoogle_cloud_storage_devel:
 - '2.22'
+libwebp_base:
+- '1'
 libxml2:
 - '2'
 lz4_c:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -30,6 +30,8 @@ libgoogle_cloud_devel:
 - '2.22'
 libgoogle_cloud_storage_devel:
 - '2.22'
+libwebp_base:
+- '1'
 libxml2:
 - '2'
 lz4_c:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -30,6 +30,8 @@ libgoogle_cloud_devel:
 - '2.22'
 libgoogle_cloud_storage_devel:
 - '2.22'
+libwebp_base:
+- '1'
 libxml2:
 - '2'
 lz4_c:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -24,6 +24,8 @@ libgoogle_cloud_devel:
 - '2.22'
 libgoogle_cloud_storage_devel:
 - '2.22'
+libwebp_base:
+- '1'
 lz4_c:
 - 1.9.3
 openssl:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ requirements:
     - libgoogle-cloud-devel
     - libgoogle-cloud-storage-devel
     - libcurl
+    - libwebp-base
     - lz4-c
     - openssl
     - spdlog

--- a/recipe/tiledb-patches/system-ports/libwebp/portfile.cmake
+++ b/recipe/tiledb-patches/system-ports/libwebp/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/recipe/tiledb-patches/system-ports/libwebp/vcpkg.json
+++ b/recipe/tiledb-patches/system-ports/libwebp/vcpkg.json
@@ -1,0 +1,57 @@
+{
+  "name": "libwebp",
+  "version-string": "system",
+  "features": {
+    "all": {
+      "description": "enable all features except for swap16bitcsp"
+    },
+    "anim": {
+      "description": "Build animation utilities."
+    },
+    "cwebp": {
+      "description": "Build the cwebp command line tool."
+    },
+    "dwebp": {
+      "description": "Build the dwebp command line tool."
+    },
+    "extras": {
+      "description": "Build extras. (Doesn't include vwebp-sdl.)"
+    },
+    "gif2webp": {
+      "description": "Build the gif2webp conversion tool."
+    },
+    "img2webp": {
+      "description": "Build the img2webp animation tool."
+    },
+    "info": {
+      "description": "Build the webpinfo command line tool."
+    },
+    "libbwebpmux": {
+      "description": "Obsolete, use feature libwebpmux instead."
+    },
+    "libwebpmux": {
+      "description": "Build the libwebpmux library"
+    },
+    "mux": {
+      "description": "Build the webpmux command line tool."
+    },
+    "nearlossless": {
+      "description": "Enable near-lossless encoding"
+    },
+    "simd": {
+      "description": "Enable any SIMD optimization."
+    },
+    "swap16bitcsp": {
+      "description": "Enable byte swap for 16 bit colorspaces."
+    },
+    "unicode": {
+      "description": "Build Unicode executables. (Adds definition UNICODE and _UNICODE)"
+    },
+    "vwebp": {
+      "description": "Build the vwebp viewer tool."
+    },
+    "vwebp-sdl": {
+      "description": "Build the vwebp viewer tool for SDL."
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

conda-forge/libwebp-base-feedstock#20 added CMake config files for all platforms, allowing us to depend on it, instead of building libwebp ourselves with vcpkg.