### PR TITLE
[ci skip] Backport ABI migrations to branch 2.22.x

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,6 @@
 bot:
   abi_migration_branches:
-  - 2.21.x
+  - 2.22.x
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

Now that 2.23 was released (#283), we need to start backporting the ABI migrations to 2.22.

I created the branch [`2.22.x`](https://github.com/conda-forge/tiledb-feedstock/tree/2.22.x) from commit 01cf999

```sh
git checkout -b 2.22.x 01cf999
## Switched to a new branch '2.22.x'
git log -n 1 --oneline
## 01cf999 (HEAD -> 2.22.x) Rebuild for spdlog 1.13 (#281)
git push upstream 2.22.x
```

There is no need to bump the build number, rerender, or anything like that. This is simply to configure the conda-forge migration bot to support the `2.22.x` branch.
