### PR TITLE
Build without the superbuild.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,6 +9,7 @@ pushd "%SRC_DIR%"\build
 cmake -G Ninja ^
       -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
       -DCMAKE_BUILD_TYPE=Release ^
+      -DTILEDB_CMAKE_IDE=ON ^
       -DTILEDB_WERROR=OFF ^
       -DTILEDB_TESTS=OFF ^
       -DTILEDB_AZURE=ON ^
@@ -23,12 +24,6 @@ cmake -G Ninja ^
       ..
 if errorlevel 1 exit 1
 
-cmake --build . -j
+cmake --build . -j --target install
 if errorlevel 1 exit 1
-
-pushd "tiledb"
-cmake --build . --target install
-if errorlevel 1 exit 1
-popd
-
 popd

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,6 +6,9 @@ xcopy /Y /S /I "%RECIPE_DIR%\tiledb-patches" "%SRC_DIR%"
 mkdir "%SRC_DIR%"\build
 pushd "%SRC_DIR%"\build
 
+REM We use -DTILEDB_CMAKE_IDE=ON to disable the superbuild, because
+REM -DTILEDB_SUPERBUILD=OFF also disables auto-downloading vcpkg.
+
 cmake -G Ninja ^
       -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
       -DCMAKE_BUILD_TYPE=Release ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -53,6 +53,9 @@ print_logs()
   done;
 }
 
+# We use -DTILEDB_CMAKE_IDE=ON to disable the superbuild, because
+# -DTILEDB_SUPERBUILD=OFF also disables auto-downloading vcpkg.
+
 mkdir build && cd build
 if ! cmake ${CMAKE_ARGS} \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -57,6 +57,7 @@ mkdir build && cd build
 if ! cmake ${CMAKE_ARGS} \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_BUILD_TYPE=Release \
+  -DTILEDB_CMAKE_IDE=ON \
   -DTILEDB_WERROR=OFF \
   -DTILEDB_TESTS=OFF \
   -DTILEDB_INSTALL_LIBDIR=lib \
@@ -75,12 +76,7 @@ then
   print_logs
   exit 1
 fi
-if ! make -j ${CPU_COUNT}
-then
-  print_logs
-  exit 1
-fi
-if ! make -C tiledb install
+if ! make -j ${CPU_COUNT} install
 then
   print_logs
   exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ source:
     # After lz4 publishes a unified CMake target with https://github.com/lz4/lz4/pull/1372,
     # we will have to align Conda, vcpkg and TileDB, and then we can remove this patch.
     - lz4-fix.patch
+    # https://github.com/TileDB-Inc/TileDB/pull/4995
+    - pr-4995.patch
 
 build:
   number: 1

--- a/recipe/pr-4995.patch
+++ b/recipe/pr-4995.patch
@@ -1,0 +1,53 @@
+diff --git a/cmake/Modules/DetectStdPmr.cmake b/cmake/Modules/DetectStdPmr.cmake
+index 3f96e94..37a6edc 100644
+--- a/cmake/Modules/DetectStdPmr.cmake
++++ b/cmake/Modules/DetectStdPmr.cmake
+@@ -31,8 +31,7 @@
+ # binary dies with a dyld missing symbol error.
+ 
+ if (ENV{MACOSX_DEPLOYMENT_TARGET})
+-  string(COMPARE LESS "$ENV{MACOSX_DEPLOYMENT_TARGET}" "14" MACOS_BAD_PMR_SUPPORT)
+-  if (MACOS_BAD_PMR_SUPPORT)
++  if (ENV{MACOSX_DEPLOYMENT_TARGET} STRLESS "14")
+     set(TILEDB_USE_CPP17_PMR ON)
+     message(STATUS "Using vendored cpp17::pmr for polymorphic allocators")
+     return()
+@@ -41,27 +40,22 @@ endif()
+ 
+ # Otherwise, if we're not building a targeted macOS version, we just detect
+ # whether std::pmr is available.
+-#
+-# However CMake makes this extra awesome because try_run appears to have
+-# changed in a backwards compatible manner. We'll just version check for
+-# selecting which to run.
+ 
+ if (CMAKE_VERSION VERSION_LESS "3.25")
+-  try_run(
+-    TILEDB_CAN_RUN_STD_PMR
+-    TILEDB_CAN_COMPILE_STD_PMR
+-    "${CMAKE_CURRENT_BINARY_DIR}"
+-    "${CMAKE_SOURCE_DIR}/cmake/inputs/detect_std_pmr.cc"
+-    )
+-else()
+-  try_run(
+-    TILEDB_CAN_RUN_STD_PMR
+-    TILEDB_CAN_COMPILE_STD_PMR
+-    SOURCES "${CMAKE_SOURCE_DIR}/cmake/inputs/detect_std_pmr.cc"
++try_compile(
++  TILEDB_CAN_COMPILE_STD_PMR
++  "${CMAKE_CURRENT_BINARY_DIR}"
++  "${CMAKE_SOURCE_DIR}/cmake/inputs/detect_std_pmr.cc"
+   )
++else()
++# CMake 3.25+ has a better signature for try_compile.
++try_compile(
++  TILEDB_CAN_COMPILE_STD_PMR
++  SOURCES "${CMAKE_SOURCE_DIR}/cmake/inputs/detect_std_pmr.cc"
++)
+ endif()
+ 
+-if ("${TILEDB_CAN_COMPILE_STD_PMR}" AND "${TILEDB_CAN_RUN_STD_PMR}" EQUAL 0)
++if (TILEDB_CAN_COMPILE_STD_PMR)
+   message(STATUS "Using std::pmr for polymorphic allocators")
+ else()
+   set(TILEDB_USE_CPP17_PMR ON)


### PR DESCRIPTION
This PR updates the build scripts to configure and build TileDB as a single CMake project, without the superbuild. Fixes #289 for reasons I do not understand.