### PR TITLE
Migrate to libgoogle-cloud 2.25

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -29,9 +29,9 @@ libabseil:
 libcurl:
 - '8'
 libgoogle_cloud_devel:
-- '2.24'
+- '2.25'
 libgoogle_cloud_storage_devel:
-- '2.24'
+- '2.25'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -33,9 +33,9 @@ libabseil:
 libcurl:
 - '8'
 libgoogle_cloud_devel:
-- '2.24'
+- '2.25'
 libgoogle_cloud_storage_devel:
-- '2.24'
+- '2.25'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -29,9 +29,9 @@ libabseil:
 libcurl:
 - '8'
 libgoogle_cloud_devel:
-- '2.24'
+- '2.25'
 libgoogle_cloud_storage_devel:
-- '2.24'
+- '2.25'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/migrations/libgoogle_cloud225.yaml
+++ b/.ci_support/migrations/libgoogle_cloud225.yaml
@@ -1,0 +1,46 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libgoogle_cloud 2.25
+  kind: version
+  migration_number: 1
+google_cloud_cpp:
+- '2.25'
+libgoogle_cloud:
+- '2.25'
+libgoogle_cloud_aiplatform_devel:
+- '2.25'
+libgoogle_cloud_all_devel:
+- '2.25'
+libgoogle_cloud_automl_devel:
+- '2.25'
+libgoogle_cloud_bigquery_devel:
+- '2.25'
+libgoogle_cloud_bigtable_devel:
+- '2.25'
+libgoogle_cloud_compute_devel:
+- '2.25'
+libgoogle_cloud_devel:
+- '2.25'
+libgoogle_cloud_dialogflow_cx_devel:
+- '2.25'
+libgoogle_cloud_dialogflow_es_devel:
+- '2.25'
+libgoogle_cloud_discoveryengine_devel:
+- '2.25'
+libgoogle_cloud_dlp_devel:
+- '2.25'
+libgoogle_cloud_iam_devel:
+- '2.25'
+libgoogle_cloud_oauth2_devel:
+- '2.25'
+libgoogle_cloud_policytroubleshooter_devel:
+- '2.25'
+libgoogle_cloud_pubsub_devel:
+- '2.25'
+libgoogle_cloud_spanner_devel:
+- '2.25'
+libgoogle_cloud_speech_devel:
+- '2.25'
+libgoogle_cloud_storage_devel:
+- '2.25'
+migrator_ts: 1718174493.939952

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -29,9 +29,9 @@ libabseil:
 libcurl:
 - '8'
 libgoogle_cloud_devel:
-- '2.24'
+- '2.25'
 libgoogle_cloud_storage_devel:
-- '2.24'
+- '2.25'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -29,9 +29,9 @@ libabseil:
 libcurl:
 - '8'
 libgoogle_cloud_devel:
-- '2.24'
+- '2.25'
 libgoogle_cloud_storage_devel:
-- '2.24'
+- '2.25'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -23,9 +23,9 @@ libcrc32c:
 libcurl:
 - '8'
 libgoogle_cloud_devel:
-- '2.24'
+- '2.25'
 libgoogle_cloud_storage_devel:
-- '2.24'
+- '2.25'
 libwebp_base:
 - '1'
 lz4_c:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - lz4-fix.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
     - {{ pin_subpackage('tiledb', max_pin='x.x') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

**Explanation:**

* The migration to libgoogle-cloud 2.25 was started about 11 hours ago (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6029)
* It was applied to arrow-cpp-feedstock first about 6 hours ago (https://github.com/conda-forge/arrow-cpp-feedstock/pull/1439), though it is taking some time to backport it to the various branches (https://github.com/conda-forge/arrow-cpp-feedstock/pulls?q=is%3Apr+libgoogle-cloud+2.25+). Currently it has been applied to 13, 15, and 16, with only 14 still pending
* As is typical, whenever a migration has been applied to arrow-cpp-feedstock but hasn't yet been applied to tiledb-feedstock, our conda feedstocks with a combined C++ library and Python client (ie VCF and SOMA), fail with a conda solver error. This time is no exception.
* The PR to update tiledb-vcf-feedstock to 0.33.0 (with tiledb 2.24) is blocked by this migration-induced conda solver error (https://github.com/TileDB-Inc/tiledb-vcf-feedstock/pull/121#issuecomment-2163534277)
* The nightly tiledbsoma-feedstock build is also broken by the same solver error (https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/170#issuecomment-2163540737)

We can monitor the migration from the [conda-forge status page](https://conda-forge.org/status/) at https://conda-forge.org/status/migration/libgoogle_cloud225. However, in order to unblock VCF and SOMA, I manually created the PR (by copying the migration file from arrow-cpp-feedstock).

Bigger picture: Why can't the conda solver simply install a previous version of libarrow that was built against libgoogle-cloud 2.24? I have never been able to figure this out. But this problem seems to only happen in our recipes with multiple outputs, so I assume there must be some additional constraints on the solver in this situation.