### PR TITLE
Remove pin to Visual Studio 17.10 (cl.exe 19.40)

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -22,8 +22,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-cxx_compiler_version:
-- '19.40'
 fmt:
 - '11'
 libabseil:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,9 +2,6 @@ c_compiler:    # [win]
   - vs2022       # [win]
 cxx_compiler:  # [win]
   - vs2022       # [win]
-# Temporary: Pin win build to Visual Studio 17.10
-cxx_compiler_version:  # [win]
-  - 19.40          # [win]
 # We should be able to remove c_stdlib_version in the future once the mechanics
 # of this new pin has been fully worked out in the conda-forge ecosystem and
 # tooling


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
---

Closes #341

Unblocks #346 

If this works, then I'll backport to the 2.25.x branch

Explanation: Azure has been slowing migrating (over weeks) to Visual Studio 17.11 and then rolling back to 17.10, which breaks our builds. Hopefully this transition to 17.11 is finally permanent

xref: https://github.com/actions/runner-images/pull/10608, https://github.com/actions/runner-images/pull/10490#issuecomment-2318463571, https://github.com/actions/runner-images/issues/10448#issuecomment-2338301212
