### PR TITLE
Build with clang 18

### DIFF
--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -31,7 +31,7 @@ curl:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 fmt:
 - '11'
 libabseil:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,7 +7,3 @@ cxx_compiler:  # [win]
 # tooling
 c_stdlib_version:    # [win]
   - 2022             # [win]
-# Delay clang 18 update for osx-arm64
-# https://github.com/conda-forge/tiledb-feedstock/pull/367
-cxx_compiler_version:  # [osx and arm64]
-  - 17                 # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a1d42e675a983291c1a0edd1a13f70e26649700160bb2bee5d6011a2af55837a
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
     - {{ pin_subpackage('tiledb', max_pin='x.x') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

Test PR to build osx-* binaries with clang 18

* conda-forge updated from clang 17 to clang 18 a few days ago (Oct 30th) (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6571)
* our nightly osx-arm64 feedstock builds failed that same night (reported the morning of Oct 31st) (https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/150)