### PR TITLE
Install capnproto from conda-forge

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -16,6 +16,8 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
+capnproto:
+- 1.0.2
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -18,6 +18,8 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
+capnproto:
+- 1.0.2
 cdt_arch:
 - aarch64
 cdt_name:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -16,6 +16,8 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
+capnproto:
+- 1.0.2
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -20,6 +20,8 @@ c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
 - '10.13'
+capnproto:
+- 1.0.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -20,6 +20,8 @@ c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
 - '11.0'
+capnproto:
+- 1.0.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -16,6 +16,8 @@ c_stdlib:
 - vs
 c_stdlib_version:
 - '2022'
+capnproto:
+- 1.0.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,6 +3,11 @@ setlocal EnableDelayedExpansion
 REM Copy tiledb-patches to the source directory
 xcopy /Y /S /I "%RECIPE_DIR%\tiledb-patches" "%SRC_DIR%"
 
+REM Regenerate the capnp serialization files with the version installed in Conda.
+REM This allows updating capnproto independently of upstream tiledb.
+%BUILD_PREFIX%\Library\bin\capnp compile -I %BUILD_PREFIX%\Library\include -oc++:%SRC_DIR%\tiledb\sm\serialization %SRC_DIR%\tiledb\sm\serialization\tiledb-rest.capnp --src-prefix=%SRC_DIR%\tiledb\sm\serialization
+if errorlevel 1 exit 1
+
 mkdir "%SRC_DIR%"\build
 pushd "%SRC_DIR%"\build
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -53,6 +53,13 @@ print_logs()
   done;
 }
 
+# Regenerate the capnp serialization files with the version installed in Conda.
+# This allows updating capnproto independently of upstream tiledb.
+if ! $BUILD_PREFIX/bin/capnp compile -I $BUILD_PREFIX/include -oc++:$SRC_DIR/tiledb/sm/serialization $SRC_DIR/tiledb/sm/serialization/tiledb-rest.capnp --src-prefix=$SRC_DIR/tiledb/sm/serialization
+then
+  exit 1
+fi
+
 # We use -DTILEDB_CMAKE_IDE=ON to disable the superbuild, because
 # -DTILEDB_SUPERBUILD=OFF also disables auto-downloading vcpkg.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - tar  # [not win]
     # These are declared as vcpkg dependencies by TileDB but are not actually used.
     - libxml2  # [not win]
+    - capnproto
   host:
     - aws-sdk-cpp
     - aws-crt-cpp
@@ -38,7 +39,7 @@ requirements:
     - azure-storage-common-cpp
     - azure-storage-blobs-cpp
     - bzip2
-    - capnproto 1.0.1
+    - capnproto
     - fmt
     - libabseil
     - libgoogle-cloud-devel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - azure-storage-common-cpp
     - azure-storage-blobs-cpp
     - bzip2
+    - capnproto
     - fmt
     - libabseil
     - libgoogle-cloud-devel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 255218aebd3ef5af4b8deb3be58f877fda335d5abc1c097a33f6741bf259a68d
 
 build:
-  number: 7
+  number: 8
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
     - {{ pin_subpackage('tiledb', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - azure-storage-common-cpp
     - azure-storage-blobs-cpp
     - bzip2
-    - capnproto
+    - capnproto 1.0.1
     - fmt
     - libabseil
     - libgoogle-cloud-devel

--- a/recipe/tiledb-patches/system-ports/README.md
+++ b/recipe/tiledb-patches/system-ports/README.md
@@ -20,7 +20,7 @@ The `vcpkg.json` should contain:
 
 1. A `name` field with a value equal to the port's name.
 2. A `version-string` field with a value equal to `system`.
-3. A `features` field with a list of the port's features that TileDB uses, with each feature containing only the `description` field.
+3. A `features` field with a list of the port's features that TileDB uses, with each feature containing only the `description` field. You can start by copy-pasting the `features` from the `vkpkg.json` file in the [ports subdirectory](https://github.com/microsoft/vcpkg/tree/master/ports) of the vcpkg repository.
 
 To show an example, suppose TileDB started depending on package `foo`, that also exists in conda-forge. This is the `vcpkg.json` file as exists in the vcpkg repo:
 

--- a/recipe/tiledb-patches/system-ports/capnproto/portfile.cmake
+++ b/recipe/tiledb-patches/system-ports/capnproto/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/recipe/tiledb-patches/system-ports/capnproto/vcpkg.json
+++ b/recipe/tiledb-patches/system-ports/capnproto/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "capnproto",
+  "version-string": "system",
+  "features": {
+    "openssl": {
+      "description": "Build libkj-tls by linking against OpenSSL."
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

As tracked in https://github.com/conda-forge/tiledb-feedstock/pull/242#issuecomment-1979127009, we will migrate dependencies from vcpkg to conda once a suitable binary is available from conda-forge.

I recently build capnproto for linux-aarch64 and linux-ppc64le (https://github.com/conda-forge/capnproto-feedstock/pull/48, https://github.com/conda-forge/capnproto-feedstock/pull/50, https://github.com/conda-forge/capnproto-feedstock/pull/54), so now we should be able to install it from conda-forge.

More urgently, we recently started getting compilation errors when building capnproto from source via vcpkg for our cross-compiled osx-arm64 builds when conda-forge updated to clang 18 (#367, https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/150). Today I had to pin clang 17 for osx-arm64 in order to merge the latest migration PRs (#368, #369). If this build succeeds, I'll next try clang 18.
