### PR TITLE
[ci skip] Backport ABI migrations to branch 2.26.x

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,6 @@
 bot:
   abi_migration_branches:
-  - 2.25.x
+  - 2.26.x
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

Created new branch [2.26.x](https://github.com/conda-forge/tiledb-feedstock/tree/2.26.x) from aa79484fccadf94fad2d61de7faa82c8dde98894 and rerendered

```sh
git checkout -b 2.26.x aa79484fccadf94fad2d61de7faa82c8dde98894
rm -r ~/.cache/conda-smithy/
conda smithy rerender --commit auto
git push upstream 2.26.x
```

xref: #345,#394
