### PR TITLE
[ci skip] Stop backporting migrations to 2.26.x branch

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,6 @@
-bot:
-  abi_migration_branches:
-  - 2.26.x
+#bot:
+#  abi_migration_branches:
+#  - 2.26.x
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64


### PR DESCRIPTION
Everything has migrated to 2.27, so it's no longer necessary to backport conda-forge migrations for 2.26.

But when we update to 2.28, we should enable migration backports to 2.27 until everything has migrated.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Note that this setting is read directly from `conda-forge.yml`, so it doesn't require rerendering to take effect.