### PR TITLE
vs2022 is now the conda-forge default

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -14,8 +14,6 @@ bzip2:
 - '1'
 c_stdlib:
 - vs
-c_stdlib_version:
-- '2022'
 capnproto:
 - 1.2.0
 channel_sources:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,0 @@
-c_compiler:    # [win]
-  - vs2022       # [win]
-cxx_compiler:  # [win]
-  - vs2022       # [win]
-# We should be able to remove c_stdlib_version in the future once the mechanics
-# of this new pin has been fully worked out in the conda-forge ecosystem and
-# tooling
-c_stdlib_version:    # [win]
-  - 2022             # [win]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

Visual Studio 2022 is now the default windows compiler for conda-forge feedstocks ([pin](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/01056ff70029cb387abf794da1fe2d6756d17ff4/recipe/conda_build_config.yaml#L26), [announcement](https://conda-forge.org/news/2025/06/11/moving-to-vs2022/)) so we know longer need to manually opt-in to compile with vs2022.

xref: https://github.com/conda-forge/conda-forge.github.io/issues/2138, https://github.com/conda-forge/tiledb-feedstock/commit/c1837f8ed1a8d1f1001b1c51b91e6b072b02311f

The goal of this PR is purely to reduce the maintenance burden going forward. It has no effect on the binary produced on Windows. Unfortunately I think the pin `"c_stdlib_version": "2022",` (which now appears to be unnecessary; I added back when stdlib was first being rolled out) does contribute to the build hash, so this might cause a new Windows binary to be uploaded. I still don't think this warrants uploading all new binaries on all the other platforms (ie if I bump the build number), but I know others feel differently, so please let me know.