### PR TITLE
Pass `-D_LIBCPP_DISABLE_AVAILABILITY` on osx-arm64 too

### DIFF
--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -31,7 +31,7 @@ curl:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '18'
+- '19'
 fmt:
 - '11.2'
 libabseil:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,7 +11,7 @@ export CXXFLAGS="${CXXFLAGS//-Werror/}"
 export CMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}
 
 # https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk
-if [[ $target_platform == osx-64  ]]; then
+if [[ $target_platform == osx-* ]]; then
   CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 fi
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-c_compiler_version:    # [osx and arm64]
-- 18                   # [osx and arm64]
-cxx_compiler_version:  # [osx and arm64]
-- 18                   # [osx and arm64]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

Closes #451 
Hat tip to @teo-tsirpanis for the idea

Turns out we had only been passing `-D_LIBCPP_DISABLE_AVAILABILITY` on osx-64 but not osx-arm64. Unclear to me how we got away with only needing to follow the [conda-forge recommendation](https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk) for osx-64 for so long, but it makes sense to extend this to osx-arm64.

https://github.com/conda-forge/tiledb-feedstock/blob/021573ba5dec3a77d627adacea0093541577fbfa/recipe/build.sh#L13-L16

Also, I didn't bump the build number. There's no real rush to upload a new binary even for osx-arm64. There will be a subsequent migration PR soon enough. I plan to add `[ci skip]` to the squashed commit to avoid the upload step.