### PR TITLE
[ci skip] Opt-in to continue building on Azure

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -9,8 +9,11 @@ github:
   branch_name: main
   tooling_branch_name: main
 provider:
-  linux_aarch64: default
-  linux_ppc64le: default
+  linux_64: azure
+  osx_64: azure
+  win_64: azure
+  linux_aarch64: azure
+  linux_ppc64le: azure
   win: azure
 test: native_and_emulated
 travis:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

conda-forge recently migrated the [default CI provider to GitHub Actions](https://conda-forge.org/news/2026/03/08/move-to-github-actions/). This PR pins the [provider](https://conda-forge.org/docs/maintainer/conda_forge_yml/#provider) to Azure because we have built [infrastructure to run nightly feedstock builds](https://github.com/TileDB-Inc/conda-forge-nightly-controller/blob/af8acc8e7e58c1a5838cea7ad8d0ab992b01287b/.github/workflows/check-azure-status.yml) that assumes they are run on Azure (note that these run on our organization's Azure account, not conda-forge's).

xref: https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/380